### PR TITLE
Update to Dropdown Scale by Factor Block

### DIFF
--- a/src/csdt/gui.js
+++ b/src/csdt/gui.js
@@ -216,6 +216,11 @@ SpriteMorph.prototype.init = function (globals) {
     this.borderSize = 0;
     this.normalExtent = new Point(60, 60); // only for costume-less situation
     this.lineList = []; //For borders
+
+    // This is used by the new scale by factor block to switch back the costume
+    this.scaleByFactorCostume = "";
+    this.hasScaledX = false;
+    this.hasScaledY = false;
 };
 
 // Overrides palette with tutorial functionaliity (objects.js)


### PR DESCRIPTION
Overrides the size and set costume block, along with spritemorph to now check for scaled x or y axis. This allows users that use the set size block to basically reset their costume back to the original default.